### PR TITLE
feat(args): Add -d option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 #[derive(Clap, Debug)]
 #[clap(author, version)]
 pub struct App {
+    /// Uses default commit types, Cargo.toml requires no changes.
+    #[clap(long, short = 'd')]
+    pub default: bool,
     /// Opens the user's editor after the questioning process.
     #[clap(long, short = 'e')]
     pub edit: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod cargo;
 mod git;
 mod questions;
 
-fn run_dialog() -> Option<SurveyResults> {
+fn run_dialog(app: &App) -> Option<SurveyResults> {
     let manifest = parse_manifest().unwrap();
     if let Some(package) = manifest.package {
         if let Some(metadata) = package.metadata {
@@ -33,8 +33,11 @@ fn run_dialog() -> Option<SurveyResults> {
             }
 
             return Some(ask(types));
+        } else if app.default {
+            // Use default scopes only.
+            return Some(ask(DEFAULT_TYPES.clone()));
         } else {
-            eprintln!("Please specify allowed scopes inside of your Cargo.toml file under the `package.metadata.cz` key!");
+            eprintln!("Please specify allowed scopes inside of your Cargo.toml file under the `package.metadata.commits` key!");
         }
     }
 
@@ -49,7 +52,7 @@ fn create_commit(commit_msg: &str, repo: &Path) {
 fn run(app: App) {
     // No point to continue if repo doesn't exist or there are no staged files
     if check_staged_files_exist(app.repo_path.as_path()) {
-        let survey = run_dialog();
+        let survey = run_dialog(&app);
         let commit_msg = survey.map(generate_commit_msg).and_then(|msg| {
             if app.edit {
                 edit::edit(msg).ok()


### PR DESCRIPTION
I was thinking about an additional command line switch to just use default commit types without modifying `Cargo.toml`.

The rationale for this would be: when collaborating on a bigger project where `Cargo.toml` changes are frequent I would like to exclude the `[package.metadata.commits]` section from my commits so as not to force my private preference of tools onto the rest of the team.

Does this make sense?